### PR TITLE
Add rtd link and thicket logo to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/llnl/thicket-tutorial/develop)
 
+
+# <img src="https://raw.githubusercontent.com/llnl/thicket/develop/logo-notext.png" width="64" valign="middle" alt="thicket"/> Thicket
+
+
 Thicket is a python-based toolkit for Exploratory Data Analysis (EDA) of
 parallel performance data that enables performance optimization and
 understanding of applications' performance on supercomputers. It bridges the
@@ -7,6 +11,9 @@ performance tool gap between being able to consider only a single instance of a
 simulation run (e.g., single platform, single measurement tool, or single
 scale) and finding actionable insights in multi-dimensional, multi-scale,
 multi-architecture, and multi-tool performance datasets.
+
+You can find detailed documentation, along with non-interactive tutorials from this repository of Thicket in the
+[ReadtheDocs](https://thicket.readthedocs.io/en/latest/).
 
 This repository contains materials for Thicket's hands-on tutorial. You can do
 all of the exercises on your own laptop using BinderHub.


### PR DESCRIPTION
The goal of this PR is to add a link referencing the Read The Docs designated for thicket and the logo for thicket.