### PR TITLE
Updated extrap notebook to use total time.

### DIFF
--- a/notebooks/02_extrap-with-metadata-aggregated.ipynb
+++ b/notebooks/02_extrap-with-metadata-aggregated.ipynb
@@ -121,8 +121,7 @@
     "    t_ens,\n",
     "    \"jobsize\",\n",
     "    chosen_metrics=[\n",
-    "        \"Avg time/rank\",\n",
-    "        \"Max time/rank\",\n",
+    "        \"Total time\",\n",
     "    ],\n",
     ")\n",
     "\n",
@@ -185,7 +184,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_obj = t_ens.statsframe.dataframe.at[t_ens.statsframe.dataframe.index[0], \"Avg time/rank_extrap-model\"]"
+    "model_obj = t_ens.statsframe.dataframe.at[t_ens.statsframe.dataframe.index[0], \"Total time_extrap-model\"]"
    ]
   },
   {
@@ -243,7 +242,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.8.13"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Updated the extra-p notebook to use total time as a metric instead of avg time per rank, so that plots show scaling correctly. See screenshot:

<img width="624" alt="Screenshot 2023-08-08 at 7 23 37 PM" src="https://github.com/LLNL/thicket-tutorial/assets/19738708/82bf3355-ab47-482e-a439-bf8dc45c9a79">
