### PR TITLE
Update Tutorial for new Thicket.tree() Functionality

### DIFF
--- a/notebooks/01_thicket_tutorial.ipynb
+++ b/notebooks/01_thicket_tutorial.ipynb
@@ -221,9 +221,9 @@
    "id": "d985a808",
    "metadata": {},
    "source": [
-    "#### Visualize the performance data table\n",
+    "#### Visualize performance metrics on the tree\n",
     "\n",
-    "With the `Thicket.tree()` function, we can visualize different metrics in the performance data table and the relationship with the call tree."
+    "With the `Thicket.tree()` function, we can visualize different metrics in the performance data table on nodes in the call tree for a single profile. By default, the first profile in the table will be selected."
    ]
   },
   {
@@ -241,7 +241,7 @@
    "id": "519ddbb5",
    "metadata": {},
    "source": [
-    "Visualize the second performance profile using the `indices` parameter to select its index in the performance data table."
+    "Visualize a specific profile using the `indices` parameter to select its index from the performance data table."
    ]
   },
   {
@@ -777,11 +777,11 @@
     "tags": []
    },
    "source": [
-    "#### Visualize aggregated statistics\n",
+    "#### Visualize aggregated statistics on the tree\n",
     "\n",
-    "We can visualize columns in the aggregated statistics table using `Thicket.statsframe.tree()`.\n",
+    "We can visualize columns from the aggregated statistics table on the call tree using `Thicket.statsframe.tree()`.\n",
     "\n",
-    "Note: `Thicket.statsframe.tree()` is different than `Thicket.tree()`. The former visualizes the aggregated statistics table, while the latter visualizes the performance data table."
+    "Note: `Thicket.statsframe.tree()` is different than `Thicket.tree()`. The former visualizes metrics from the aggregated statistics table, while the latter visualizes from the performance data table."
    ]
   },
   {

--- a/notebooks/01_thicket_tutorial.ipynb
+++ b/notebooks/01_thicket_tutorial.ipynb
@@ -163,7 +163,7 @@
    },
    "outputs": [],
    "source": [
-    "help(tt.stats.median)"
+    "help(tt.Thicket.from_caliperreader)"
    ]
   },
   {
@@ -214,6 +214,44 @@
    "outputs": [],
    "source": [
     "display(HTML(th_lassen.dataframe.to_html()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d985a808",
+   "metadata": {},
+   "source": [
+    "#### Visualize the performance data table\n",
+    "\n",
+    "With the `Thicket.tree()` function, we can visualize different metrics in the performance data table and the relationship with the call tree."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a602cf90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(th_lassen.tree(metric_column=\"Avg time/rank\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "519ddbb5",
+   "metadata": {},
+   "source": [
+    "Visualize the second performance profile using the `indices` parameter to select its index in the performance data table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7239b854",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(th_lassen.tree(metric_column=\"Avg time/rank\", indices=(2458031255)))"
    ]
   },
   {
@@ -739,7 +777,11 @@
     "tags": []
    },
    "source": [
-    "#### View aggregated statistics call tree"
+    "#### Visualize aggregated statistics\n",
+    "\n",
+    "We can visualize columns in the aggregated statistics table using `Thicket.statsframe.tree()`.\n",
+    "\n",
+    "Note: `Thicket.statsframe.tree()` is different than `Thicket.tree()`. The former visualizes the aggregated statistics table, while the latter visualizes the performance data table."
    ]
   },
   {
@@ -810,7 +852,7 @@
    },
    "outputs": [],
    "source": [
-    "print(th_lassen.statsframe.tree(\"Total time_median\"))"
+    "print(th_lassen.tree(\"Total time\"))"
    ]
   },
   {
@@ -872,8 +914,7 @@
     "    \n",
     "# applying the query on the lassen thicket\n",
     "th_algorithm_ex1 = th_lassen.query(alg_query_ex1)\n",
-    "tt.stats.median(th_algorithm_ex1, columns=[\"Total time\"])\n",
-    "print(th_algorithm_ex1.statsframe.tree(\"Total time_median\"))"
+    "print(th_algorithm_ex1.tree(\"Total time\"))"
    ]
   },
   {
@@ -935,8 +976,7 @@
     "\n",
     "# applying the second query on the lassen thicket\n",
     "th_algorithm_ex2 = th_lassen.query(alg_query_ex2)\n",
-    "tt.stats.median(th_algorithm_ex2, columns=[\"Total time\"])\n",
-    "print(th_algorithm_ex2.statsframe.tree(\"Total time_median\"))"
+    "print(th_algorithm_ex2.tree(\"Total time\"))"
    ]
   },
   {
@@ -1094,6 +1134,7 @@
    "source": [
     "plt.figure(figsize=(30, 30))\n",
     "metrics = [\"Total time_median\"]\n",
+    "tt.stats.median(th_algorithm_ex1, columns=[\"Total time\"])\n",
     "tt.stats.display_heatmap(th_algorithm_ex1, columns=metrics)"
    ]
   }

--- a/notebooks/05_thicket_query_language.ipynb
+++ b/notebooks/05_thicket_query_language.ipynb
@@ -122,103 +122,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc16d40e",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001883,
-     "end_time": "2024-03-26T22:19:44.288035",
-     "exception": false,
-     "start_time": "2024-03-26T22:19:44.286152",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## 3. More Information on a Function\n",
-    "***\n",
-    "You can use the help() method within Python to see the information for a given object. You can do this by typing help(object). \n",
-    "This will allow you to see the arguments for the function, and what will be returned. An example is below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6f7e0bb9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-03-26T22:19:44.291998Z",
-     "iopub.status.busy": "2024-03-26T22:19:44.291897Z",
-     "iopub.status.idle": "2024-03-26T22:19:44.294641Z",
-     "shell.execute_reply": "2024-03-26T22:19:44.294309Z"
-    },
-    "papermill": {
-     "duration": 0.005455,
-     "end_time": "2024-03-26T22:19:44.295200",
-     "exception": false,
-     "start_time": "2024-03-26T22:19:44.289745",
-     "status": "completed"
-    },
-    "scrolled": false,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "help(tt.stats.median)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "83a23b65",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001887,
-     "end_time": "2024-03-26T22:19:44.298862",
-     "exception": false,
-     "start_time": "2024-03-26T22:19:44.296975",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## 4. Append Statistical Calculation(s)\n",
-    "***\n",
-    "\n",
-    "We can calculate statistical aggregations per-node in the performance data and append the values to the aggregated statistics table. In the example below, we calculate the per-node median time across 4 profiles and append the median to the statistics table. The new column is called `Total time_median`. \n",
-    "\n",
-    "Why is this important for this notebook?\n",
-    "\n",
-    "When the nodes in the performance data table change, the aggregated statistics table will change depending on the metric. Therefore, the aggregated statistics table is cleared after a query has been applied. In the examples further down, we use an appended column (specifically the median of total time) as the metric to print the call trees."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "140ad4a4",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-03-26T22:19:44.302810Z",
-     "iopub.status.busy": "2024-03-26T22:19:44.302714Z",
-     "iopub.status.idle": "2024-03-26T22:19:44.309439Z",
-     "shell.execute_reply": "2024-03-26T22:19:44.309142Z"
-    },
-    "papermill": {
-     "duration": 0.009311,
-     "end_time": "2024-03-26T22:19:44.309964",
-     "exception": false,
-     "start_time": "2024-03-26T22:19:44.300653",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "metrics = [\"Total time\"]\n",
-    "tt.stats.median(th_lassen, columns=metrics)\n",
-    "th_lassen.statsframe.dataframe"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "d603a02a",
    "metadata": {
     "papermill": {
@@ -231,7 +134,7 @@
     "tags": []
    },
    "source": [
-    "## 5. Thicket Query Language \n",
+    "## 3. Thicket Query Language \n",
     "\n",
     "**Use the Query Language**\n",
     "\n",
@@ -262,7 +165,7 @@
    "outputs": [],
    "source": [
     "print(\"Initial call tree:\")\n",
-    "print(th_lassen.statsframe.tree(\"Total time_median\"))"
+    "print(th_lassen.tree(\"Total time\"))"
    ]
   },
   {
@@ -325,8 +228,7 @@
     "\n",
     "# applying the first query on the lassen thicket\n",
     "th_ex1 = th_lassen.query(query_ex1)\n",
-    "tt.stats.median(th_ex1, columns=[\"Total time\"])\n",
-    "print(th_ex1.statsframe.tree(\"Total time_median\"))"
+    "print(th_ex1.tree(\"Total time\"))"
    ]
   },
   {
@@ -386,8 +288,7 @@
     "\n",
     "# applying the second query on the lassen thicket\n",
     "th_ex2 = th_lassen.query(query_ex2)\n",
-    "tt.stats.median(th_ex2, columns=[\"Total time\"])\n",
-    "print(th_ex2.statsframe.tree(\"Total time_median\"))"
+    "print(th_ex2.tree(\"Total time\"))"
    ]
   },
   {
@@ -456,8 +357,7 @@
     "\n",
     "# applying the third query on the lassen thicket\n",
     "th_ex3 = th_lassen.query(query_ex3)\n",
-    "tt.stats.median(th_ex3, columns=[\"Total time\"])\n",
-    "print(th_ex3.statsframe.tree(\"Total time_median\"))"
+    "print(th_ex3.tree(\"Total time\"))"
    ]
   },
   {
@@ -521,8 +421,7 @@
     "\n",
     "# applying the fourth query on the lassen thicket\n",
     "th_ex4 = th_lassen.query(query_ex4)\n",
-    "tt.stats.median(th_ex4, columns=[\"Total time\"])\n",
-    "print(th_ex4.statsframe.tree(\"Total time_median\"))"
+    "print(th_ex4.tree(\"Total time\"))"
    ]
   },
   {
@@ -583,8 +482,7 @@
     "\n",
     "# applying the fifth query on the lassen thicket\n",
     "th_ex5 = th_lassen.query(query_ex5)\n",
-    "tt.stats.median(th_ex5, columns=[\"Total time\"])\n",
-    "print(th_ex5.statsframe.tree(\"Total time_median\"))"
+    "print(th_ex5.tree(\"Total time\"))"
    ]
   }
  ],


### PR DESCRIPTION
As of Thicket v2024.1.0, `Thicket.tree()` now prints on the performance data table instead of the statistics table. This PR updates the tutorial notebooks to match this change.