### PR TITLE
Improve Concat Thicket Example

### DIFF
--- a/notebooks/01_thicket_tutorial.ipynb
+++ b/notebooks/01_thicket_tutorial.ipynb
@@ -723,6 +723,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: This is equivalent to tt.Thicket.from_caliperreader(data) where \"data\" is all of the values in the data dictionary.\n",
     "tk = tt.Thicket.concat_thickets(\n",
     "    axis=\"index\",\n",
     "    thickets=[block_128, block_256, block_512, block_1024],\n",

--- a/notebooks/01_thicket_tutorial.ipynb
+++ b/notebooks/01_thicket_tutorial.ipynb
@@ -52,6 +52,7 @@
    },
    "outputs": [],
    "source": [
+    "from glob import glob\n",
     "import re\n",
     "\n",
     "import numpy as np\n",
@@ -252,154 +253,6 @@
    "outputs": [],
    "source": [
     "print(th_lassen.tree(metric_column=\"Avg time/rank\", indices=(2458031255)))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "90326f42",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004047,
-     "end_time": "2024-03-26T22:19:27.740080",
-     "exception": false,
-     "start_time": "2024-03-26T22:19:27.736033",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "#### Composing multiple thickets\n",
-    "We can compose thickets in a hierarchical, horizontal ordering using thicket's `columnar_join` function. In this example, we compose profiles of four different problem sizes and four different block sizes seamlessly."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b159b0c0",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-03-26T22:19:27.748814Z",
-     "iopub.status.busy": "2024-03-26T22:19:27.748704Z",
-     "iopub.status.idle": "2024-03-26T22:19:27.751317Z",
-     "shell.execute_reply": "2024-03-26T22:19:27.751085Z"
-    },
-    "papermill": {
-     "duration": 0.007654,
-     "end_time": "2024-03-26T22:19:27.751858",
-     "exception": false,
-     "start_time": "2024-03-26T22:19:27.744204",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "data = {\n",
-    "    \"block_128\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_128.cali\" for x in problem_sizes],\n",
-    "    \"block_256\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_256.cali\" for x in problem_sizes],\n",
-    "    \"block_512\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_512.cali\" for x in problem_sizes],\n",
-    "    \"block_1024\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_1024.cali\" for x in problem_sizes],\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6c17da78",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-03-26T22:19:27.760599Z",
-     "iopub.status.busy": "2024-03-26T22:19:27.760503Z",
-     "iopub.status.idle": "2024-03-26T22:19:28.147486Z",
-     "shell.execute_reply": "2024-03-26T22:19:28.147170Z"
-    },
-    "papermill": {
-     "duration": 0.392164,
-     "end_time": "2024-03-26T22:19:28.148143",
-     "exception": false,
-     "start_time": "2024-03-26T22:19:27.755979",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "block_128 = tt.Thicket.from_caliperreader(data[\"block_128\"])\n",
-    "block_256 = tt.Thicket.from_caliperreader(data[\"block_256\"])\n",
-    "block_512 = tt.Thicket.from_caliperreader(data[\"block_512\"])\n",
-    "block_1024 = tt.Thicket.from_caliperreader(data[\"block_1024\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "66ab720b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-03-26T22:19:28.157485Z",
-     "iopub.status.busy": "2024-03-26T22:19:28.157389Z",
-     "iopub.status.idle": "2024-03-26T22:19:28.230538Z",
-     "shell.execute_reply": "2024-03-26T22:19:28.230188Z"
-    },
-    "papermill": {
-     "duration": 0.078558,
-     "end_time": "2024-03-26T22:19:28.231331",
-     "exception": false,
-     "start_time": "2024-03-26T22:19:28.152773",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "th_cj = tt.Thicket.concat_thickets(\n",
-    "    axis=\"columns\",\n",
-    "    thickets=[block_128, block_256, block_512, block_1024],\n",
-    "    headers=[\"Block 128\", \"Block 256\", \"Block 512\", \"Block 1024\"],\n",
-    "    metadata_key=\"ProblemSizeRunParam\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b8ad9292",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004208,
-     "end_time": "2024-03-26T22:19:28.240170",
-     "exception": false,
-     "start_time": "2024-03-26T22:19:28.235962",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "#### View combined thicket's performance data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1753f3ec",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-03-26T22:19:28.249178Z",
-     "iopub.status.busy": "2024-03-26T22:19:28.249072Z",
-     "iopub.status.idle": "2024-03-26T22:19:28.382330Z",
-     "shell.execute_reply": "2024-03-26T22:19:28.382013Z"
-    },
-    "papermill": {
-     "duration": 0.139421,
-     "end_time": "2024-03-26T22:19:28.383801",
-     "exception": false,
-     "start_time": "2024-03-26T22:19:28.244380",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "display(HTML(th_cj.dataframe.to_html()))"
    ]
   },
   {
@@ -811,6 +664,139 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ff3d03c8",
+   "metadata": {},
+   "source": [
+    "## 5. Miscellaneous"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0a93a51",
+   "metadata": {},
+   "source": [
+    "#### 5.1 Composing Thickets\n",
+    "\n",
+    "We can concatenate Thickets in different ways using the `Thicket.concat_thickets()` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6b6efbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = {\n",
+    "    \"block_128\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_128.cali\" for x in problem_sizes],\n",
+    "    \"block_256\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_256.cali\" for x in problem_sizes],\n",
+    "    \"block_512\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_512.cali\" for x in problem_sizes],\n",
+    "    \"block_1024\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_1024.cali\" for x in problem_sizes],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00ae04a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "block_128 = tt.Thicket.from_caliperreader(data[\"block_128\"])\n",
+    "block_256 = tt.Thicket.from_caliperreader(data[\"block_256\"])\n",
+    "block_512 = tt.Thicket.from_caliperreader(data[\"block_512\"])\n",
+    "block_1024 = tt.Thicket.from_caliperreader(data[\"block_1024\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d524066",
+   "metadata": {},
+   "source": [
+    "##### 5.1.1 Concatenate on index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47bc1714",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tk = tt.Thicket.concat_thickets(\n",
+    "    axis=\"index\",\n",
+    "    thickets=[block_128, block_256, block_512, block_1024],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bb229fb",
+   "metadata": {},
+   "source": [
+    "##### 5.1.2 Concatenate on columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab923432",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ctk = tt.Thicket.concat_thickets(\n",
+    "    axis=\"columns\",\n",
+    "    thickets=[block_128, block_256, block_512, block_1024],\n",
+    "    headers=[\"Block 128\", \"Block 256\", \"Block 512\", \"Block 1024\"],\n",
+    "    metadata_key=\"ProblemSizeRunParam\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70821260",
+   "metadata": {},
+   "source": [
+    "##### 5.1.3 Alternative example of column concatenation using groupby"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec881a36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tk = tt.Thicket.from_caliperreader(glob('../data/lassen/**/1/*.cali', recursive=True))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21939fb0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gb = tk.groupby(\"tuning\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aab1ab79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ctk = tt.Thicket.concat_thickets(\n",
+    "    axis=\"columns\",\n",
+    "    thickets=list(gb.values()),\n",
+    "    headers=list(gb.keys()),\n",
+    "    metadata_key=\"ProblemSizeRunParam\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7b0cd1b2",
    "metadata": {
     "papermill": {
@@ -823,7 +809,7 @@
     "tags": []
    },
    "source": [
-    "#### Use the query language\n",
+    "#### 5.2 Use the query language\n",
     "\n",
     "Thicket's query language provides users the capability to select or `query` specific nodes based on the call tree of the thicket. The performance data is then updated as part of the operation. \n",
     "\n",
@@ -993,7 +979,7 @@
     "tags": []
    },
    "source": [
-    "#### Display histogram\n",
+    "#### 5.3 Display histogram\n",
     "\n",
     "The `display_histogram()` function allows users to select a node and metric value (a column in the performance data table) for which a histogram is generated.\n",
     "\n",
@@ -1087,7 +1073,7 @@
     "tags": []
    },
    "source": [
-    "#### Display heatmap\n",
+    "#### 5.4 Display heatmap\n",
     "\n",
     "The `display_heatmap()` function allows users to select column(s) from the performance data table, for which a heatmap is generated based on the values of the column.\n",
     "\n",
@@ -1155,7 +1141,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.11.7"
   },
   "papermill": {
    "default_parameters": {},

--- a/notebooks/01_thicket_tutorial.ipynb
+++ b/notebooks/01_thicket_tutorial.ipynb
@@ -664,140 +664,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff3d03c8",
-   "metadata": {},
-   "source": [
-    "## 5. Miscellaneous"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d0a93a51",
-   "metadata": {},
-   "source": [
-    "#### 5.1 Composing Thickets\n",
-    "\n",
-    "We can concatenate Thickets in different ways using the `Thicket.concat_thickets()` function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c6b6efbc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data = {\n",
-    "    \"block_128\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_128.cali\" for x in problem_sizes],\n",
-    "    \"block_256\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_256.cali\" for x in problem_sizes],\n",
-    "    \"block_512\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_512.cali\" for x in problem_sizes],\n",
-    "    \"block_1024\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_1024.cali\" for x in problem_sizes],\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "00ae04a4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "block_128 = tt.Thicket.from_caliperreader(data[\"block_128\"])\n",
-    "block_256 = tt.Thicket.from_caliperreader(data[\"block_256\"])\n",
-    "block_512 = tt.Thicket.from_caliperreader(data[\"block_512\"])\n",
-    "block_1024 = tt.Thicket.from_caliperreader(data[\"block_1024\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9d524066",
-   "metadata": {},
-   "source": [
-    "##### 5.1.1 Concatenate on index"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "47bc1714",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Note: This is equivalent to tt.Thicket.from_caliperreader(data) where \"data\" is all of the values in the data dictionary.\n",
-    "tk = tt.Thicket.concat_thickets(\n",
-    "    axis=\"index\",\n",
-    "    thickets=[block_128, block_256, block_512, block_1024],\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7bb229fb",
-   "metadata": {},
-   "source": [
-    "##### 5.1.2 Concatenate on columns"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ab923432",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ctk = tt.Thicket.concat_thickets(\n",
-    "    axis=\"columns\",\n",
-    "    thickets=[block_128, block_256, block_512, block_1024],\n",
-    "    headers=[\"Block 128\", \"Block 256\", \"Block 512\", \"Block 1024\"],\n",
-    "    metadata_key=\"ProblemSizeRunParam\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "70821260",
-   "metadata": {},
-   "source": [
-    "##### 5.1.3 Alternative example of column concatenation using groupby"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ec881a36",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tk = tt.Thicket.from_caliperreader(glob('../data/lassen/**/1/*.cali', recursive=True))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "21939fb0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gb = tk.groupby(\"tuning\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aab1ab79",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ctk = tt.Thicket.concat_thickets(\n",
-    "    axis=\"columns\",\n",
-    "    thickets=list(gb.values()),\n",
-    "    headers=list(gb.keys()),\n",
-    "    metadata_key=\"ProblemSizeRunParam\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "7b0cd1b2",
    "metadata": {
     "papermill": {
@@ -810,7 +676,7 @@
     "tags": []
    },
    "source": [
-    "#### 5.2 Use the query language\n",
+    "#### Use the query language\n",
     "\n",
     "Thicket's query language provides users the capability to select or `query` specific nodes based on the call tree of the thicket. The performance data is then updated as part of the operation. \n",
     "\n",
@@ -980,7 +846,7 @@
     "tags": []
    },
    "source": [
-    "#### 5.3 Display histogram\n",
+    "#### Display histogram\n",
     "\n",
     "The `display_histogram()` function allows users to select a node and metric value (a column in the performance data table) for which a histogram is generated.\n",
     "\n",
@@ -1074,7 +940,7 @@
     "tags": []
    },
    "source": [
-    "#### 5.4 Display heatmap\n",
+    "#### Display heatmap\n",
     "\n",
     "The `display_heatmap()` function allows users to select column(s) from the performance data table, for which a heatmap is generated based on the values of the column.\n",
     "\n",
@@ -1124,6 +990,170 @@
     "tt.stats.median(th_algorithm_ex1, columns=[\"Total time\"])\n",
     "tt.stats.display_heatmap(th_algorithm_ex1, columns=metrics)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff3d03c8",
+   "metadata": {},
+   "source": [
+    "## 5. Concatenating Multiple Thickets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0a93a51",
+   "metadata": {},
+   "source": [
+    "#### 5.1 Composing Thickets\n",
+    "\n",
+    "We can concatenate Thickets in different ways using the `Thicket.concat_thickets()` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6b6efbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = {\n",
+    "    \"block_128\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_128.cali\" for x in problem_sizes],\n",
+    "    \"block_256\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_256.cali\" for x in problem_sizes],\n",
+    "    \"block_512\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_512.cali\" for x in problem_sizes],\n",
+    "    \"block_1024\": [f\"../data/lassen/clang10.0.1_nvcc10.2.89_{x}/1/Base_CUDA-block_1024.cali\" for x in problem_sizes],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00ae04a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "block_128 = tt.Thicket.from_caliperreader(data[\"block_128\"])\n",
+    "block_256 = tt.Thicket.from_caliperreader(data[\"block_256\"])\n",
+    "block_512 = tt.Thicket.from_caliperreader(data[\"block_512\"])\n",
+    "block_1024 = tt.Thicket.from_caliperreader(data[\"block_1024\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d524066",
+   "metadata": {},
+   "source": [
+    "##### 5.1.1 Concatenate on index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47bc1714",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note: This is equivalent to tt.Thicket.from_caliperreader(data) where \"data\" is all of the values in the data dictionary.\n",
+    "tk = tt.Thicket.concat_thickets(\n",
+    "    axis=\"index\",\n",
+    "    thickets=[block_128, block_256, block_512, block_1024],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50b8f1a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(HTML(tk.dataframe.to_html()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bb229fb",
+   "metadata": {},
+   "source": [
+    "##### 5.1.2 Concatenate on columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab923432",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ctk = tt.Thicket.concat_thickets(\n",
+    "    axis=\"columns\",\n",
+    "    thickets=[block_128, block_256, block_512, block_1024],\n",
+    "    headers=[\"Block 128\", \"Block 256\", \"Block 512\", \"Block 1024\"],\n",
+    "    metadata_key=\"ProblemSizeRunParam\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ade73d3e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(HTML(ctk.dataframe.to_html()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70821260",
+   "metadata": {},
+   "source": [
+    "##### 5.1.3 Alternative example of column concatenation using groupby"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec881a36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tk = tt.Thicket.from_caliperreader(glob('../data/lassen/**/1/*.cali', recursive=True))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21939fb0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gb = tk.groupby(\"tuning\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aab1ab79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ctk = tt.Thicket.concat_thickets(\n",
+    "    axis=\"columns\",\n",
+    "    thickets=list(gb.values()),\n",
+    "    headers=list(gb.keys()),\n",
+    "    metadata_key=\"ProblemSizeRunParam\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77a9b9b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(HTML(ctk.dataframe.to_html()))"
+   ]
   }
  ],
  "metadata": {
@@ -1142,7 +1172,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.9.12"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
Improve the `concat_thickets` example and make a separate section. Also add additional example for `concat_thickets(axis="columns")` using groupby.