### PR TITLE
Disable tqdm throughout, fixup notebook documentation

### DIFF
--- a/notebooks/01_thicket_tutorial.ipynb
+++ b/notebooks/01_thicket_tutorial.ipynb
@@ -139,8 +139,8 @@
     "lassen2 = [f\"../data/lassen/clang10.0.1_nvcc10.2.89_1048576/1/Base_CUDA-block_256.cali\"]\n",
     "\n",
     "# generate thicket(s)\n",
-    "th_lassen = tt.Thicket.from_caliperreader(lassen1)\n",
-    "th_obj = tt.Thicket.from_caliperreader(lassen1 + lassen2)"
+    "th_lassen = tt.Thicket.from_caliperreader(lassen1, disable_tqdm=True)\n",
+    "th_obj = tt.Thicket.from_caliperreader(lassen1 + lassen2, disable_tqdm=True)"
    ]
   },
   {
@@ -1055,10 +1055,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "block_128 = tt.Thicket.from_caliperreader(data[\"block_128\"])\n",
-    "block_256 = tt.Thicket.from_caliperreader(data[\"block_256\"])\n",
-    "block_512 = tt.Thicket.from_caliperreader(data[\"block_512\"])\n",
-    "block_1024 = tt.Thicket.from_caliperreader(data[\"block_1024\"])"
+    "block_128 = tt.Thicket.from_caliperreader(data[\"block_128\"], disable_tqdm=True)\n",
+    "block_256 = tt.Thicket.from_caliperreader(data[\"block_256\"], disable_tqdm=True)\n",
+    "block_512 = tt.Thicket.from_caliperreader(data[\"block_512\"], disable_tqdm=True)\n",
+    "block_1024 = tt.Thicket.from_caliperreader(data[\"block_1024\"], disable_tqdm=True)"
    ]
   },
   {
@@ -1080,6 +1080,7 @@
     "tk = tt.Thicket.concat_thickets(\n",
     "    axis=\"index\",\n",
     "    thickets=[block_128, block_256, block_512, block_1024],\n",
+    "    disable_tqdm=True\n",
     ")"
    ]
   },
@@ -1112,7 +1113,8 @@
     "    axis=\"columns\",\n",
     "    thickets=[block_128, block_256, block_512, block_1024],\n",
     "    headers=[\"Block 128\", \"Block 256\", \"Block 512\", \"Block 1024\"],\n",
-    "    metadata_key=\"ProblemSizeRunParam\"\n",
+    "    metadata_key=\"ProblemSizeRunParam\",\n",
+    "    disable_tqdm=True\n",
     ")"
    ]
   },
@@ -1141,7 +1143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tk = tt.Thicket.from_caliperreader(glob('../data/lassen/**/1/*.cali', recursive=True))"
+    "tk = tt.Thicket.from_caliperreader(glob('../data/lassen/**/1/*.cali', recursive=True), disable_tqdm=True)"
    ]
   },
   {
@@ -1165,7 +1167,8 @@
     "    axis=\"columns\",\n",
     "    thickets=list(gb.values()),\n",
     "    headers=list(gb.keys()),\n",
-    "    metadata_key=\"ProblemSizeRunParam\"\n",
+    "    metadata_key=\"ProblemSizeRunParam\",\n",
+    "    disable_tqdm=True\n",
     ")"
    ]
   },

--- a/notebooks/01_thicket_tutorial.ipynb
+++ b/notebooks/01_thicket_tutorial.ipynb
@@ -1080,7 +1080,7 @@
     "tk = tt.Thicket.concat_thickets(\n",
     "    axis=\"index\",\n",
     "    thickets=[block_128, block_256, block_512, block_1024],\n",
-    "    disable_tqdm=True\n",
+    "    disable_tqdm=True,\n",
     ")"
    ]
   },
@@ -1114,7 +1114,7 @@
     "    thickets=[block_128, block_256, block_512, block_1024],\n",
     "    headers=[\"Block 128\", \"Block 256\", \"Block 512\", \"Block 1024\"],\n",
     "    metadata_key=\"ProblemSizeRunParam\",\n",
-    "    disable_tqdm=True\n",
+    "    disable_tqdm=True,\n",
     ")"
    ]
   },
@@ -1168,7 +1168,7 @@
     "    thickets=list(gb.values()),\n",
     "    headers=list(gb.keys()),\n",
     "    metadata_key=\"ProblemSizeRunParam\",\n",
-    "    disable_tqdm=True\n",
+    "    disable_tqdm=True,\n",
     ")"
    ]
   },

--- a/notebooks/02_thicket_rajaperf_clustering.ipynb
+++ b/notebooks/02_thicket_rajaperf_clustering.ipynb
@@ -321,7 +321,7 @@
     "        real_metrics.append(exc_time_metric)\n",
     "    subthickets = []\n",
     "    for directory in directories:\n",
-    "        thicket = Thicket.from_caliperreader(directory)\n",
+    "        thicket = Thicket.from_caliperreader(directory, disable_tqdm=True)\n",
     "        thicket.dataframe = thicket.dataframe[[*real_metrics]]\n",
     "        thicket.exc_metrics = [m for m in thicket.dataframe.columns if m in thicket.exc_metrics]\n",
     "        thicket.inc_metrics = [m for m in thicket.dataframe.columns if m in thicket.inc_metrics]\n",
@@ -331,7 +331,7 @@
     "            else:\n",
     "                raise ValueError(\"Could not set default metric\")\n",
     "        subthickets.append(thicket)\n",
-    "    return Thicket.concat_thickets(axis=\"index\", thickets=subthickets)"
+    "    return Thicket.concat_thickets(axis=\"index\", thickets=subthickets, disable_tqdm=True)"
    ]
   },
   {

--- a/notebooks/03_extrap-with-metadata-aggregated.ipynb
+++ b/notebooks/03_extrap-with-metadata-aggregated.ipynb
@@ -129,7 +129,7 @@
    "outputs": [],
    "source": [
     "data = \"../data/mpi_scaling_cali\"\n",
-    "t_ens = th.Thicket.from_caliperreader(data)"
+    "t_ens = th.Thicket.from_caliperreader(data, disable_tqdm=True)"
    ]
   },
   {

--- a/notebooks/04_stats-functions.ipynb
+++ b/notebooks/04_stats-functions.ipynb
@@ -201,11 +201,7 @@
     "    axis=\"columns\",\n",
     "    thickets=[clang_th, gcc_th],\n",
     "    headers=[\"Clang\", \"GCC\"],\n",
-<<<<<<< HEAD
     "    disable_tqdm=True,\n",
-=======
-    "    disable_tqdm=True\n",
->>>>>>> ef184e39 (disable tqdm for docs rendering)
     ")\n",
     "combined_th.dataframe.head(5)"
    ]
@@ -2422,15 +2418,11 @@
    },
    "outputs": [],
    "source": [
-<<<<<<< HEAD
     "stk = th.Thicket.from_statsframes(\n",
     "    [clang_th, gcc_th],\n",
     "    metadata_key=\"compiler\",\n",
     "    disable_tqdm=True,\n",
     ")\n",
-=======
-    "stk = th.Thicket.from_statsframes([clang_th, gcc_th], metadata_key=\"compiler\", disable_tqdm=True)\n",
->>>>>>> ef184e39 (disable tqdm for docs rendering)
     "stk.dataframe"
    ]
   }

--- a/notebooks/04_stats-functions.ipynb
+++ b/notebooks/04_stats-functions.ipynb
@@ -201,7 +201,11 @@
     "    axis=\"columns\",\n",
     "    thickets=[clang_th, gcc_th],\n",
     "    headers=[\"Clang\", \"GCC\"],\n",
+<<<<<<< HEAD
     "    disable_tqdm=True,\n",
+=======
+    "    disable_tqdm=True\n",
+>>>>>>> ef184e39 (disable tqdm for docs rendering)
     ")\n",
     "combined_th.dataframe.head(5)"
    ]
@@ -2418,11 +2422,15 @@
    },
    "outputs": [],
    "source": [
+<<<<<<< HEAD
     "stk = th.Thicket.from_statsframes(\n",
     "    [clang_th, gcc_th],\n",
     "    metadata_key=\"compiler\",\n",
     "    disable_tqdm=True,\n",
     ")\n",
+=======
+    "stk = th.Thicket.from_statsframes([clang_th, gcc_th], metadata_key=\"compiler\", disable_tqdm=True)\n",
+>>>>>>> ef184e39 (disable tqdm for docs rendering)
     "stk.dataframe"
    ]
   }

--- a/notebooks/04_stats-functions.ipynb
+++ b/notebooks/04_stats-functions.ipynb
@@ -2228,7 +2228,7 @@
    "source": [
     "### 6.5 Displaying Violinplot Thicket\n",
     "\n",
-    "The `display_violinplot_thicket` function will display a violinplot for each user passed node(s) and column(s) and each thicket. The passed nodes and columns must be from the performance data table."
+    "The `display_violinplot_thicket` function will display a violinplot for each user passed node(s) and column(s) from multiple thickets. The passed nodes and columns must be from the performance data table."
    ]
   },
   {

--- a/notebooks/04_stats-functions.ipynb
+++ b/notebooks/04_stats-functions.ipynb
@@ -2153,7 +2153,7 @@
    "source": [
     "### 6.4 Displaying Violinplot\n",
     "\n",
-    "The `display_violinplot` function will display a violin plot for each passed in node(s) and column(s). The passed nodes and columns must be from the performance data table. "
+    "The `display_violinplot` function will display a violin plot for each passed in node(s) and column(s) in a single thicket. The passed nodes and columns must be from the performance data table. "
    ]
   },
   {
@@ -2219,35 +2219,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e634a05f",
-   "metadata": {},
-   "source": [
-    "**Example of Error if Not Passing Hatchet Node**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b87fd04f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# n = \"not_hatchet_node\"\n",
-    "# th.stats.display_histogram(\n",
-    "#     combined_th,\n",
-    "#     node=n,\n",
-    "#     column=(\"Clang\", \"Machine clears\")\n",
-    "# )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "2bbb977e",
    "metadata": {},
    "source": [
     "### 6.5 Displaying Violinplot Thicket\n",
     "\n",
-    "The `display_violinplot_thicket` function will display a violinplot for each user passed node(s) and column(s). The passed nodes and columns must be from the performance data table."
+    "The `display_violinplot_thicket` function will display a violinplot for each user passed node(s) and column(s) and each thicket. The passed nodes and columns must be from the performance data table."
    ]
   },
   {
@@ -2380,29 +2357,6 @@
     "#     thickets=thickets,\n",
     "#     nodes=n,\n",
     "#     columns=columns\n",
-    "# )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2538d05d",
-   "metadata": {},
-   "source": [
-    "**Example of Error if Not Passing Hatchet Node**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e0e4c21c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# n = \"not_hatchet_node\"\n",
-    "# th.stats.display_histogram(\n",
-    "#     combined_th,\n",
-    "#     node=n,\n",
-    "#     column=(\"Clang\", \"Machine clears\")\n",
     "# )"
    ]
   },

--- a/notebooks/05_thicket_query_language.ipynb
+++ b/notebooks/05_thicket_query_language.ipynb
@@ -139,7 +139,7 @@
     "lassen2 = [f\"../data/lassen/clang10.0.1_nvcc10.2.89_1048576/1/Base_CUDA-block_256.cali\"]\n",
     "\n",
     "# generate thicket(s)\n",
-    "th_lassen = tt.Thicket.from_caliperreader(lassen1)"
+    "th_lassen = tt.Thicket.from_caliperreader(lassen1, disable_tqdm=True)"
    ]
   },
   {

--- a/notebooks/06_groupby_aggregate_of_multirun_data.ipynb
+++ b/notebooks/06_groupby_aggregate_of_multirun_data.ipynb
@@ -70,7 +70,7 @@
    "outputs": [],
    "source": [
     "data = glob(\"../data/lassen/clang10.0.1_nvcc10.2.89_1048576/**/*.cali\", recursive=True)\n",
-    "tk = th.Thicket.from_caliperreader(data)"
+    "tk = th.Thicket.from_caliperreader(data, disable_tqdm=True)"
    ]
   },
   {

--- a/notebooks/06_groupby_aggregate_of_multirun_data.ipynb
+++ b/notebooks/06_groupby_aggregate_of_multirun_data.ipynb
@@ -30,7 +30,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6586fbfb",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2024-03-26T22:19:31.397846Z",
@@ -143,7 +142,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tk_agg = gb.agg(np.mean)\n",
+    "tk_agg = gb.agg(np.mean, disable_tqdm=True)\n",
     "\n",
     "display(tk_agg.dataframe)"
    ]


### PR DESCRIPTION
- disable tqdm, fixes papermill rendering on readthedocs
- stats: remove cells showing improper use of functions for display violinplot