### PR TITLE
Remove mybinder Links from Thicket Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,7 @@ all of the exercises on your own laptop using BinderHub.
 
 You find Thicket itself in its Github repository: https://github.com/llnl/thicket
 
-### Running the notebooks online
-
-We use [BinderHub](https://mybinder.org) to create a shareable and interactive
-environment of the notebooks within a live JupyterHub instance.
-
-You can access the interactive environment at this
-[link](https://mybinder.org/v2/gh/llnl/thicket-tutorial/develop)
-or by clicking the badge at the top of this file.
-
-### Running the notebooks locally
+### Running the notebooks
 
 #### Docker
 

--- a/notebooks/01_thicket_tutorial.ipynb
+++ b/notebooks/01_thicket_tutorial.ipynb
@@ -18,12 +18,6 @@
     "\n",
     "Thicket is a python-based toolkit for Exploratory Data Analysis (EDA) of parallel performance data that enables performance optimization and understanding of applications’ performance on supercomputers. It bridges the performance tool gap between being able to consider only a single instance of a simulation run (e.g., single platform, single measurement tool, or single scale) and finding actionable insights in multi-dimensional, multi-scale, multi-architecture, and multi-tool performance datasets.\n",
     "\n",
-    "**NOTE: An interactive version of this notebook is available in the Binder environment.**\n",
-    "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/llnl/thicket-tutorial/develop)\n",
-    "\n",
-    "***\n",
-    "\n",
     "## 1. Import Necessary Packages\n",
     "\n",
     "To explore the structure and various capabilities of thicket components, we begin by importing necessary packages. These include python extensions and thicket's statistical functions."

--- a/notebooks/02_thicket_rajaperf_clustering.ipynb
+++ b/notebooks/02_thicket_rajaperf_clustering.ipynb
@@ -18,12 +18,6 @@
     "\n",
     "Thicket is a python-based toolkit for Exploratory Data Analysis (EDA) of parallel performance data that enables performance optimization and understanding of applications’ performance on supercomputers. It bridges the performance tool gap between being able to consider only a single instance of a simulation run (e.g., single platform, single measurement tool, or single scale) and finding actionable insights in multi-dimensional, multi-scale, multi-architecture, and multi-tool performance datasets.\n",
     "\n",
-    "**NOTE: An interactive version of this notebook is available in the Binder environment.**\n",
-    "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/llnl/thicket-tutorial/develop)\n",
-    "\n",
-    "***\n",
-    "\n",
     "## 1. Import Necessary Packages"
    ]
   },

--- a/notebooks/03_extrap-with-metadata-aggregated.ipynb
+++ b/notebooks/03_extrap-with-metadata-aggregated.ipynb
@@ -20,12 +20,6 @@
     "\n",
     "This notebook provides an example for using Thicket's modeling feature. The modeling capability relies on _Extra-P_ - a tool for empirical performance modeling. It can perform N-parameter modeling with up to 3 parameters (N <= 3). The models follow a so-called _Performance Model Normal Form (PMNF)_ that expresses models as a summation of polynomial and logarithmic terms. One of the biggest advantages of this modeling method is that the produced models are human-readable and easily understandable.\n",
     "\n",
-    "**NOTE: An interactive version of this notebook is available in the Binder environment.**\n",
-    "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/llnl/thicket-tutorial/develop)\n",
-    "\n",
-    "***\n",
-    "\n",
     "## 1. Import Necessary Packages\n",
     "\n",
     "To explore the capabilities of thicket with Extra-P, we begin by importing necessary packages."

--- a/notebooks/04_stats-functions.ipynb
+++ b/notebooks/04_stats-functions.ipynb
@@ -18,12 +18,6 @@
     "\n",
     "Thicket is a python-based toolkit for Exploratory Data Analysis (EDA) of parallel performance data that enables performance optimization and understanding of applications’ performance on supercomputers. It bridges the performance tool gap between being able to consider only a single instance of a simulation run (e.g., single platform, single measurement tool, or single scale) and finding actionable insights in multi-dimensional, multi-scale, multi-architecture, and multi-tool performance datasets.\n",
     "\n",
-    "**NOTE: An interactive version of this notebook is available in the Binder environment.**\n",
-    "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/llnl/thicket-tutorial/develop)\n",
-    "\n",
-    "***\n",
-    "\n",
     "## 1. Import Necessary Packages\n",
     "\n",
     "To explore the structure and various capabilities of thicket components, we begin by importing necessary packages. "

--- a/notebooks/05_thicket_query_language.ipynb
+++ b/notebooks/05_thicket_query_language.ipynb
@@ -18,12 +18,6 @@
     "\n",
     "Thicket is a python-based toolkit for Exploratory Data Analysis (EDA) of parallel performance data that enables performance optimization and understanding of applications’ performance on supercomputers. It bridges the performance tool gap between being able to consider only a single instance of a simulation run (e.g., single platform, single measurement tool, or single scale) and finding actionable insights in multi-dimensional, multi-scale, multi-architecture, and multi-tool performance datasets.\n",
     "\n",
-    "**NOTE: An interactive version of this notebook is available in the Binder environment.**\n",
-    "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/llnl/thicket-tutorial/develop)\n",
-    "\n",
-    "***\n",
-    "\n",
     "## 1. Import Necessary Packages\n",
     "\n",
     "To explore the structure and various capabilities of thicket components, we begin by importing necessary packages. These include python extensions and thicket's statistical functions."

--- a/notebooks/06_groupby_aggregate_of_multirun_data.ipynb
+++ b/notebooks/06_groupby_aggregate_of_multirun_data.ipynb
@@ -8,12 +8,6 @@
     "\n",
     "Thicket is a python-based toolkit for Exploratory Data Analysis (EDA) of parallel performance data that enables performance optimization and understanding of applications’ performance on supercomputers. It bridges the performance tool gap between being able to consider only a single instance of a simulation run (e.g., single platform, single measurement tool, or single scale) and finding actionable insights in multi-dimensional, multi-scale, multi-architecture, and multi-tool performance datasets.\n",
     "\n",
-    "**NOTE: An interactive version of this notebook is available in the Binder environment.**\n",
-    "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/llnl/thicket-tutorial/develop)\n",
-    "\n",
-    "***\n",
-    "\n",
     "## 1. Import Necessary Packages"
    ]
   },


### PR DESCRIPTION
Because mybinder.org has [lost a significant amount of funding](https://blog.jupyter.org/mybinder-org-reducing-capacity-c93ccfc6413f), the instances are often not working. Moving forward, we are going to rely on local docker and podman instances for users to run the notebooks.

This PR:
- Removes mybinder links in the notebooks.
- Removes mybinder reference in `README.md`