### PR TITLE
Add missing groupby aggregate notebook to dockerfile build

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -42,6 +42,7 @@ COPY --chown=${NB_USER} ./notebooks/02_thicket_rajaperf_clustering.ipynb ./noteb
 COPY --chown=${NB_USER} ./notebooks/03_extrap-with-metadata-aggregated.ipynb ./notebooks/03_extrap-with-metadata-aggregated.ipynb
 COPY --chown=${NB_USER} ./notebooks/04_stats-functions.ipynb ./notebooks/04_stats-functions.ipynb
 COPY --chown=${NB_USER} ./notebooks/05_thicket_query_language.ipynb ./notebooks/05_thicket_query_language.ipynb
+COPY --chown=${NB_USER} ./notebooks/06_groupby_aggregate_of_multirun_data.ipynb ./notebooks/06_groupby_aggregate_of_multirun_data.ipynb
 COPY --chown=${NB_USER} ./data/ ./data/
 
 COPY ./docker_scripts/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
`Dockerfile.local` is missing `06_groupby_aggregate_of_multirun_data.ipynb`.