### PR TITLE
Revert "thicket tutorial: compute stats on filtered thicket"

### DIFF
--- a/notebooks/01_thicket_tutorial.ipynb
+++ b/notebooks/01_thicket_tutorial.ipynb
@@ -28,6 +28,12 @@
    "execution_count": null,
    "id": "4e9d66ee",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:26.898836Z",
+     "iopub.status.busy": "2024-03-26T22:19:26.898682Z",
+     "iopub.status.idle": "2024-03-26T22:19:27.445595Z",
+     "shell.execute_reply": "2024-03-26T22:19:27.445228Z"
+    },
     "papermill": {
      "duration": 0.556743,
      "end_time": "2024-03-26T22:19:27.446317",
@@ -60,6 +66,12 @@
    "execution_count": null,
    "id": "6586fbfb",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:31.397846Z",
+     "iopub.status.busy": "2024-03-26T22:19:31.397645Z",
+     "iopub.status.idle": "2024-03-26T22:19:31.400418Z",
+     "shell.execute_reply": "2024-03-26T22:19:31.400126Z"
+    },
     "papermill": {
      "duration": 0.007031,
      "end_time": "2024-03-26T22:19:31.401094",
@@ -100,6 +112,12 @@
    "execution_count": null,
    "id": "075dda6a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:27.457941Z",
+     "iopub.status.busy": "2024-03-26T22:19:27.457819Z",
+     "iopub.status.idle": "2024-03-26T22:19:27.666450Z",
+     "shell.execute_reply": "2024-03-26T22:19:27.666096Z"
+    },
     "papermill": {
      "duration": 0.212221,
      "end_time": "2024-03-26T22:19:27.667103",
@@ -150,6 +168,12 @@
    "execution_count": null,
    "id": "80bce559",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:27.678772Z",
+     "iopub.status.busy": "2024-03-26T22:19:27.678675Z",
+     "iopub.status.idle": "2024-03-26T22:19:27.681576Z",
+     "shell.execute_reply": "2024-03-26T22:19:27.681124Z"
+    },
     "papermill": {
      "duration": 0.006557,
      "end_time": "2024-03-26T22:19:27.682218",
@@ -193,6 +217,12 @@
    "execution_count": null,
    "id": "b9c694b3",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:27.693390Z",
+     "iopub.status.busy": "2024-03-26T22:19:27.693291Z",
+     "iopub.status.idle": "2024-03-26T22:19:27.730549Z",
+     "shell.execute_reply": "2024-03-26T22:19:27.730212Z"
+    },
     "papermill": {
      "duration": 0.040864,
      "end_time": "2024-03-26T22:19:27.731205",
@@ -272,6 +302,12 @@
    "execution_count": null,
    "id": "e7569694",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:28.420881Z",
+     "iopub.status.busy": "2024-03-26T22:19:28.420761Z",
+     "iopub.status.idle": "2024-03-26T22:19:28.426274Z",
+     "shell.execute_reply": "2024-03-26T22:19:28.426040Z"
+    },
     "papermill": {
      "duration": 0.015374,
      "end_time": "2024-03-26T22:19:28.426800",
@@ -311,6 +347,12 @@
    "execution_count": null,
    "id": "a5de9a0e",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:28.463698Z",
+     "iopub.status.busy": "2024-03-26T22:19:28.463582Z",
+     "iopub.status.idle": "2024-03-26T22:19:28.470285Z",
+     "shell.execute_reply": "2024-03-26T22:19:28.470027Z"
+    },
     "papermill": {
      "duration": 0.016714,
      "end_time": "2024-03-26T22:19:28.470790",
@@ -352,6 +394,12 @@
    "execution_count": null,
    "id": "05ffaf49",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:28.508031Z",
+     "iopub.status.busy": "2024-03-26T22:19:28.507925Z",
+     "iopub.status.idle": "2024-03-26T22:19:28.537406Z",
+     "shell.execute_reply": "2024-03-26T22:19:28.537057Z"
+    },
     "papermill": {
      "duration": 0.039838,
      "end_time": "2024-03-26T22:19:28.537978",
@@ -397,6 +445,12 @@
    "execution_count": null,
    "id": "0b57311d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:28.577463Z",
+     "iopub.status.busy": "2024-03-26T22:19:28.577350Z",
+     "iopub.status.idle": "2024-03-26T22:19:28.581376Z",
+     "shell.execute_reply": "2024-03-26T22:19:28.581112Z"
+    },
     "papermill": {
      "duration": 0.014649,
      "end_time": "2024-03-26T22:19:28.581918",
@@ -435,6 +489,12 @@
    "execution_count": null,
    "id": "0c2f3ea4",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:28.620941Z",
+     "iopub.status.busy": "2024-03-26T22:19:28.620837Z",
+     "iopub.status.idle": "2024-03-26T22:19:28.649480Z",
+     "shell.execute_reply": "2024-03-26T22:19:28.649178Z"
+    },
     "papermill": {
      "duration": 0.039201,
      "end_time": "2024-03-26T22:19:28.650073",
@@ -481,6 +541,12 @@
    "execution_count": null,
    "id": "d38cc661",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:28.690346Z",
+     "iopub.status.busy": "2024-03-26T22:19:28.690226Z",
+     "iopub.status.idle": "2024-03-26T22:19:28.696332Z",
+     "shell.execute_reply": "2024-03-26T22:19:28.696064Z"
+    },
     "papermill": {
      "duration": 0.017073,
      "end_time": "2024-03-26T22:19:28.697005",
@@ -493,8 +559,8 @@
    "outputs": [],
    "source": [
     "metrics = [\"Total time\"]\n",
-    "tt.stats.median(th_stats_name, columns=metrics)\n",
-    "display(HTML(th_stats_name.statsframe.dataframe.to_html()))"
+    "tt.stats.median(th_lassen, columns=metrics)\n",
+    "display(HTML(th_lassen.statsframe.dataframe.to_html()))"
    ]
   },
   {
@@ -502,6 +568,12 @@
    "execution_count": null,
    "id": "8aacec0c",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:28.718447Z",
+     "iopub.status.busy": "2024-03-26T22:19:28.718339Z",
+     "iopub.status.idle": "2024-03-26T22:19:28.724290Z",
+     "shell.execute_reply": "2024-03-26T22:19:28.723977Z"
+    },
     "papermill": {
      "duration": 0.017692,
      "end_time": "2024-03-26T22:19:28.724882",
@@ -513,8 +585,8 @@
    },
    "outputs": [],
    "source": [
-    "tt.stats.mean(th_stats_name, columns=metrics)\n",
-    "display(HTML(th_stats_name.statsframe.dataframe.to_html()))"
+    "tt.stats.mean(th_lassen, columns=metrics)\n",
+    "display(HTML(th_lassen.statsframe.dataframe.to_html()))"
    ]
   },
   {
@@ -543,6 +615,12 @@
    "execution_count": null,
    "id": "0acd03eb",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:28.767576Z",
+     "iopub.status.busy": "2024-03-26T22:19:28.767460Z",
+     "iopub.status.idle": "2024-03-26T22:19:28.783372Z",
+     "shell.execute_reply": "2024-03-26T22:19:28.783093Z"
+    },
     "papermill": {
      "duration": 0.026997,
      "end_time": "2024-03-26T22:19:28.784039",
@@ -556,7 +634,7 @@
    "outputs": [],
    "source": [
     "tt.stats.percentiles(th_lassen, columns=metrics)\n",
-    "display(HTML(th_stats_name.statsframe.dataframe.to_html()))"
+    "display(HTML(th_lassen.statsframe.dataframe.to_html()))"
    ]
   },
   {
@@ -585,6 +663,12 @@
    "execution_count": null,
    "id": "420e8e39",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:28.826524Z",
+     "iopub.status.busy": "2024-03-26T22:19:28.826416Z",
+     "iopub.status.idle": "2024-03-26T22:19:28.832335Z",
+     "shell.execute_reply": "2024-03-26T22:19:28.832032Z"
+    },
     "papermill": {
      "duration": 0.017154,
      "end_time": "2024-03-26T22:19:28.832862",
@@ -596,7 +680,7 @@
    },
    "outputs": [],
    "source": [
-    "print(th_stats_name.statsframe.tree(metric_column=\"Total time_median\"))"
+    "print(th_lassen.statsframe.tree(metric_column=\"Total time_median\"))"
    ]
   },
   {
@@ -625,6 +709,12 @@
    "execution_count": null,
    "id": "b704a382",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:28.874152Z",
+     "iopub.status.busy": "2024-03-26T22:19:28.874053Z",
+     "iopub.status.idle": "2024-03-26T22:19:28.880315Z",
+     "shell.execute_reply": "2024-03-26T22:19:28.880055Z"
+    },
     "papermill": {
      "duration": 0.017221,
      "end_time": "2024-03-26T22:19:28.880830",
@@ -665,6 +755,12 @@
    "execution_count": null,
    "id": "809876aa",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:28.924009Z",
+     "iopub.status.busy": "2024-03-26T22:19:28.923886Z",
+     "iopub.status.idle": "2024-03-26T22:19:28.995460Z",
+     "shell.execute_reply": "2024-03-26T22:19:28.995098Z"
+    },
     "papermill": {
      "duration": 0.08347,
      "end_time": "2024-03-26T22:19:28.996109",
@@ -721,6 +817,12 @@
    "execution_count": null,
    "id": "74750802",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:29.039855Z",
+     "iopub.status.busy": "2024-03-26T22:19:29.039721Z",
+     "iopub.status.idle": "2024-03-26T22:19:29.101201Z",
+     "shell.execute_reply": "2024-03-26T22:19:29.100844Z"
+    },
     "papermill": {
      "duration": 0.073265,
      "end_time": "2024-03-26T22:19:29.101909",
@@ -796,6 +898,12 @@
    "execution_count": null,
    "id": "4f8365ec",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:29.145535Z",
+     "iopub.status.busy": "2024-03-26T22:19:29.145413Z",
+     "iopub.status.idle": "2024-03-26T22:19:29.148294Z",
+     "shell.execute_reply": "2024-03-26T22:19:29.147986Z"
+    },
     "papermill": {
      "duration": 0.014716,
      "end_time": "2024-03-26T22:19:29.148907",
@@ -815,6 +923,12 @@
    "execution_count": null,
    "id": "6d836906",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:29.170715Z",
+     "iopub.status.busy": "2024-03-26T22:19:29.170610Z",
+     "iopub.status.idle": "2024-03-26T22:19:29.265017Z",
+     "shell.execute_reply": "2024-03-26T22:19:29.264062Z"
+    },
     "papermill": {
      "duration": 0.106133,
      "end_time": "2024-03-26T22:19:29.265658",
@@ -878,6 +992,12 @@
    "execution_count": null,
    "id": "6240832a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-26T22:19:29.310996Z",
+     "iopub.status.busy": "2024-03-26T22:19:29.310872Z",
+     "iopub.status.idle": "2024-03-26T22:19:29.454444Z",
+     "shell.execute_reply": "2024-03-26T22:19:29.454095Z"
+    },
     "papermill": {
      "duration": 0.156222,
      "end_time": "2024-03-26T22:19:29.455087",
@@ -1065,7 +1185,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1079,7 +1199,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.9.12"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
Reverts LLNL/thicket-tutorial#65

Uncovered a bug in thicket's filter_stats where we were filtering the thicket graph, but not the thicket's statsframe graph. We'll fix this in the next minor release and then update the tutorial notebook.